### PR TITLE
msm8937-common: retune status bar paddings

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_padding_start">8dp</dimen>
+    <dimen name="status_bar_padding_end">0dp</dimen>
+</resources>


### PR DESCRIPTION
* this is the most appealing status bar padding i tried.

test: decompile systemUI overlay, recompile, apply to vendor/overlay, boot to homescreen.

Signed-off-by: dlwlrma123 <alexfinhart@gmail.com>
Signed-off-by: laleeroy <gabwielcastwo@gmail.com>